### PR TITLE
Quick Fix on WSL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ endif
 
 C_COMPILER = gcc
 FILES_TO_COMPILE = cp/src/argParser.c cp/src/audio.c cp/src/decodeFrame.c cp/src/drawFrame.c cp/src/help.c cp/src/main.c cp/src/processFrame.c cp/src/queue.c cp/src/threads.c cp/src/utils.c
-COMPILER_FLAGS = -w
+COMPILER_FLAGS = -w -lpthread
 LIBRARIES = -lm -lavcodec -lavformat -lavutil -lswresample -lswscale -lao
 OUTPUT_NAME = conpl
 

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,8 @@ endif
 
 C_COMPILER = gcc
 FILES_TO_COMPILE = cp/src/argParser.c cp/src/audio.c cp/src/decodeFrame.c cp/src/drawFrame.c cp/src/help.c cp/src/main.c cp/src/processFrame.c cp/src/queue.c cp/src/threads.c cp/src/utils.c
-COMPILER_FLAGS = -w -lpthread
-LIBRARIES = -lm -lavcodec -lavformat -lavutil -lswresample -lswscale -lao
+COMPILER_FLAGS = -w
+LIBRARIES = -lm -lpthread -lavcodec -lavformat -lavutil -lswresample -lswscale -lao
 OUTPUT_NAME = conpl
 
 $(OUTPUT_NAME): $(FILES_TO_COMPILE) cp/src/conplayer.h


### PR DESCRIPTION
Fix this error:
`gcc src/argParser.c src/audio.c src/decodeFrame.c src/drawFrame.c src/help.c src/main.c src/processFrame.c src/queue.c src/threads.c src/utils.c -w -lm -lavcodec -lavformat -lavutil -lswresample -lswscale -lao -o conpl
/usr/bin/ld: /tmp/cc0Lbqeb.o: undefined reference to symbol 'pthread_create@@GLIBC_2.2.5'
/usr/bin/ld: /lib/x86_64-linux-gnu/libpthread.so.0: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
make: *** [makefile:8: conpl] Error 1`

Also pretty cool project :)